### PR TITLE
Allow empty value enhancers

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -32,6 +32,23 @@ describe('FormattedEnhancedMessage', () => {
     )
   })
 
+  it('should replace enhancers without a value correctly', () => {
+    const { container } = wrappedRender(
+      <FormattedEnhancedMessage
+        enhancers={{
+          strong: name => <strong>{name}</strong>,
+          newline: () => <br />,
+        }}
+        id="greeting"
+        defaultMessage="Hi <x:strong>Daniel</x:strong>, <x:newline></x:newline>good morning!"
+      />
+    )
+
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"Hi <strong>Daniel</strong>, <br>good morning!"`
+    )
+  })
+
   it('should not fail with no enhancers provided', () => {
     const defaultMessage = 'Hi <0>Daniel</0>'
     const { container } = wrappedRender(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ interface IFormattedEnhancedMessageProps {
 }
 
 const processMessage = (message: string, enhancers: Enhancers) => {
-  const regex = /<(x:([\da-z_-]+))>(.+?)<\/\1>/gi
+  const regex = /<(x:([\da-z_-]+))>(.*?)<\/\1>/gi
   const output: ReactNode[] = []
   let result
   let key = 0


### PR DESCRIPTION
Hi, for a project I'm working on we were required to add new lines to translations. These new lines have no value and that was not possible with this library.

I've changed the regex to allow empty values. This adds more flexibility to the library.