### PR TITLE
Add support for wrapped tags

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -95,4 +95,30 @@ describe('FormattedEnhancedMessage', () => {
       `"Hi <strong>Daniel</strong>, good &lt;x:no&gt;morning&lt;/x:no&gt;!"`
     )
   })
+
+  it('should handle nested enhancers', () => {
+    const { container } = wrappedRender(
+      <FormattedEnhancedMessage
+        id="greeting"
+        defaultMessage="<x:em>Hi <x:strong>Daniel</x:strong>, good day!</x:em>"
+        enhancers={{ strong: name => <strong>{name}</strong>, em: children => <em>{children}</em> }}
+      />
+    )
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"<em>Hi <strong>Daniel</strong>, good day!</em>"`
+    )
+  })
+
+  it('should handle nested enhancers where outer is not found', () => {
+    const { container } = wrappedRender(
+      <FormattedEnhancedMessage
+        id="greeting"
+        defaultMessage="<x:em>Hi <x:strong>Daniel</x:strong>, good day!</x:em>"
+        enhancers={{ strong: name => <strong>{name}</strong> }}
+      />
+    )
+    expect(container.innerHTML).toMatchInlineSnapshot(
+      `"&lt;x:em&gt;Hi <strong>Daniel</strong>, good day!&lt;/x:em&gt;"`
+    )
+  })
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react'
 import { FormattedMessage } from 'react-intl'
 
-type ReplaceCallback = (content: string) => ReactNode
+type ReplaceCallback = (content: string | ReactNode | ReactNode[]) => ReactNode
 type Enhancers = { [key: string]: ReplaceCallback }
 
 interface IFormattedEnhancedMessageProps {
@@ -26,9 +26,9 @@ const processMessage = (message: string, enhancers: Enhancers) => {
     output.push(message.substring(0, index))
 
     if (label in enhancers) {
-      output.push(<Fragment key={key++}>{enhancers[label](value)}</Fragment>)
+      output.push(<Fragment key={key++}>{enhancers[label](processMessage(value, enhancers))}</Fragment>)
     } else {
-      output.push(match)
+      output.push(<Fragment key={key++}>{`<x:${label}>`}{processMessage(value, enhancers)}{`</x:${label}>`}</Fragment>);
     }
 
     message = message.substring(index + match.length, message.length + 1)


### PR DESCRIPTION
Introduce support for basic tag wrapping:

```jsx
<x:list><x:li>Item1</x:li><x:li>Item2</x:li></x:list>
```

So with enhancers:
```jsx
{
  list: chilren => <ul>{children}</ul>,
  li: children => <li>{children}</ul>
}
```

The output would look like:

```jsx
<ul><li>Item1</li><li>Item2</li></ul>
```

This is currently limited to not allowing duplicate tags to wrap.
This means things like <x:strong>whatever<x:strong>also strong</x:strong></x:strong> are not supported.